### PR TITLE
Run the CI on macos

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -22,8 +22,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os:
-          # https://help.github.com/en/actions/reference/virtual-environments-for-github-hosted-runners
-          - ubuntu-20.04
+          - macos-10.15
         unit: ["true"]
         include:
           - tox_env: packaging
@@ -31,16 +30,16 @@ jobs:
             python-version: 3.7
             unit: false
           - tox_env: py37
-            os: ubuntu-20.04
+            os: macos-10.15
             python-version: 3.7
           - tox_env: py38
-            os: ubuntu-20.04
+            os: macos-10.15
             python-version: 3.8
           - tox_env: py39
-            os: ubuntu-20.04
+            os: macos-10.15
             python-version: 3.9
           - tox_env: py310
-            os: ubuntu-20.04
+            os: macos-10.15
             python-version: "3.10"
 
     env:

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -29,6 +29,7 @@ jobs:
             os: ubuntu-20.04
             python-version: 3.7
             unit: false
+            skip_vagrant: true
           - tox_env: py37
             os: macos-10.15
             python-version: 3.7
@@ -48,6 +49,12 @@ jobs:
       FORCE_COLOR: 1
 
     steps:
+      - name: Check vagrant presence
+        run: |
+          vagrant version
+          vagrant plugin list
+        if: ${{ ! matrix.skip_vagrant }}
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # needed by setuptools-scm


### PR DESCRIPTION
GHA has virtualisation and vagrant only on macosx 10.15. So fix things to use it.