### PR TITLE
use generic/alpine315 and configure Vagrant

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -52,6 +52,11 @@ jobs:
       - name: Check vagrant presence
         run: |
           vagrant version
+        if: ${{ ! matrix.skip_vagrant }}
+
+      - name: Install vagrant vbguest
+        run: |
+          vagrant plugin install vagrant-vbguest
           vagrant plugin list
         if: ${{ ! matrix.skip_vagrant }}
 

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -50,7 +50,7 @@ SHELL_PROVISION_VAGRANTFILE = os.path.join(
 VM_1 = "web"
 VM_2 = "db"
 # name of the base box used for testing
-TEST_BOX_URL = "generic/alpine310"
+TEST_BOX_URL = "generic/alpine315"
 TEST_BOX_NAME = TEST_BOX_URL
 TEST_PROVIDER = "virtualbox"
 # temp dir for testing.

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -165,17 +165,15 @@ def test_parse_box_list(vm):
     """
     Test the parsing the output of the `vagrant box list` command.
     """
-    listing = """1424141572,,box-name,precise64
-1424141572,,box-provider,virtualbox
+    listing = """ 1424141572,,box-provider,virtualbox
 1424141572,,box-version,0
-1424141572,,box-name,python-vagrant-base
+1424141572,,box-name,generic/alpine315
 1424141572,,box-provider,virtualbox
 1424141572,,box-version,0
 """
     # Can compare tuples to Box class b/c Box is a collections.namedtuple.
     goal = [
-        ("precise64", "virtualbox", "0"),
-        ("python-vagrant-base", "virtualbox", "0"),
+        (TEST_BOX_NAME, "virtualbox", "0"),
     ]
     v = vagrant.Vagrant(TD)
     parsed = v._parse_box_list(listing)

--- a/tests/test_vagrant_test_case.py
+++ b/tests/test_vagrant_test_case.py
@@ -44,7 +44,7 @@ class SingleBoxTests(VagrantTestCase):
 class SpecificMultiBoxTests(VagrantTestCase):
     """Tests for a multiple box setup where only some of the boxes are to be on"""
 
-    vagrant_boxes = ["precise32"]
+    vagrant_boxes = ["generic/alpine315"]
     vagrant_root = MULTI_BOX
 
     def test_all_boxes_up(self):

--- a/tests/vagrantfiles/multi_box/Vagrantfile
+++ b/tests/vagrantfiles/multi_box/Vagrantfile
@@ -4,6 +4,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vbguest.auto_update = false
   config.vm.box = 'alpine315'
   config.vm.box_url = 'https://app.vagrantup.com/generic/boxes/alpine315/versions/3.6.10/providers/virtualbox.box'
 end

--- a/tests/vagrantfiles/multi_box/Vagrantfile
+++ b/tests/vagrantfiles/multi_box/Vagrantfile
@@ -3,13 +3,7 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
-boxes = ['precise32', 'precise64']
-
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  boxes.each do |box|
-    config.vm.define box do |conf|
-      conf.vm.box = box
-      conf.vm.box_url = "http://files.vagrantup.com/#{box}.box"
-    end
-  end
+  config.vm.box = 'alpine315'
+  config.vm.box_url = 'https://app.vagrantup.com/generic/boxes/alpine315/versions/3.6.10/providers/virtualbox.box'
 end

--- a/tests/vagrantfiles/multivm_Vagrantfile
+++ b/tests/vagrantfiles/multivm_Vagrantfile
@@ -1,15 +1,16 @@
-
 # http://docs.vagrantup.com/v2/multi-machine/index.html
 # http://docs.vagrantup.com/v2/networking/
 
 Vagrant.configure("2") do |config|
   config.vm.define :web do |web|
-    web.vm.box = "python-vagrant-base"
+    web.vbguest.auto_update = false
+    web.vm.box = "generic/alpine315"
     web.vm.network :forwarded_port, guest: 80, host: 8080
   end
 
   config.vm.define :db do |db|
-    db.vm.box = "python-vagrant-base"
+    db.vbguest.auto_update = false
+    db.vm.box = "generic/alpine315"
     db.vm.network :forwarded_port, guest: 3306, host: 3306
   end
 end

--- a/tests/vagrantfiles/shell_provision_Vagrantfile
+++ b/tests/vagrantfiles/shell_provision_Vagrantfile
@@ -1,6 +1,6 @@
-
 Vagrant.configure("2") do |config|
-  config.vm.box = "python-vagrant-base"
+  config.vbguest.auto_update = false
+  config.vm.box = "generic/alpine315"
   # test v.provision()
   config.vm.provision :shell, :inline => "echo 'foo' > /home/vagrant/python_vagrant_test_file"
 end

--- a/tests/vagrantfiles/single_box/Vagrantfile
+++ b/tests/vagrantfiles/single_box/Vagrantfile
@@ -6,6 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   (1..2).each do |i|
     config.vm.define "multialpine0#{i}" do |webserver|
+      webserver.vbguest.auto_update = false
       webserver.vm.box = "generic/alpine315"
       webserver.vm.hostname = "multialpine0#{i}"
     end

--- a/tests/vagrantfiles/single_box/Vagrantfile
+++ b/tests/vagrantfiles/single_box/Vagrantfile
@@ -4,6 +4,10 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'precise64'
-  config.vm.box_url = 'http://files.vagrantup.com/precise64.box'
+  (1..2).each do |i|
+    config.vm.define "multialpine0#{i}" do |webserver|
+      webserver.vm.box = "generic/alpine315"
+      webserver.vm.hostname = "multialpine0#{i}"
+    end
+  end
 end

--- a/tests/vagrantfiles/vm_Vagrantfile
+++ b/tests/vagrantfiles/vm_Vagrantfile
@@ -1,4 +1,4 @@
-
 Vagrant.configure("2") do |config|
-  config.vm.box = "python-vagrant-base"
+  config.vbguest.auto_update = false
+  config.vm.box = "generic/alpine315"
 end


### PR DESCRIPTION
This PR:
- upgrades `generic/alpine310` to `generic/alpine315`
- sets `config.vbguest.auto_update` to `false` because of missing `vbguest`
- replaces static unused box names with `TEST_BOX_NAME`