### PR TITLE
configure vbguest.auto_update and correct vm.box

### DIFF
--- a/tests/vagrantfiles/multi_box/Vagrantfile
+++ b/tests/vagrantfiles/multi_box/Vagrantfile
@@ -8,8 +8,9 @@ boxes = ['alpine315', 'alpine37']
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   boxes.each do |box|
     config.vm.define box do |conf|
-      conf.vm.box = box
-      conf.vm.box_url = box
+      conf.vbguest.auto_update = false if Vagrant.has_plugin?("vagrant-vbguest")
+      conf.vm.hostname = box
+      conf.vm.box = "generic/#{box}"
     end
   end
 end


### PR DESCRIPTION
This PR:
- adds `vbguest` configuration to `multi_box/Vagrantfile`
- fixes `conf.vm.box` so the boxes can be downloaded

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>