### PR TITLE
ensure boxes are destroyed during teardown and try: unlinking

### DIFF
--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -103,7 +103,6 @@ def list_box_names():
     return box_names
 
 
-
 # TEST-LEVEL SETUP AND TEARDOWN
 
 

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -108,6 +108,7 @@ def teardown():
     """
     sys.stderr.write("module teardown()\n")
     if TD is not None:
+        subprocess.check_call("vagrant destroy -f", cwd=TD, shell=True)
         shutil.rmtree(TD)
 
 
@@ -274,7 +275,11 @@ def test_vm_lifecycle(vm):
     v = vagrant.Vagrant(TD)
 
     # Test init by removing Vagrantfile, since v.init() will create one.
-    os.unlink(os.path.join(TD, "Vagrantfile"))
+    try:
+        os.unlink(os.path.join(TD, "Vagrantfile"))
+    except FileNotFoundError:
+        pass
+
     v.init(TEST_BOX_NAME)
     assert v.NOT_CREATED == v.status()[0].state
 


### PR DESCRIPTION
This PR:
- ensures a box is removed during teardown, since failed tests will create halted machines that will be left running w/o a valid Vagrantfile
- add a `try:` so tests don't fail if there isn't any Vagrantfile to remove

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>