### PR TITLE
Fix vm name in SpecificMultiBoxTests

### DIFF
--- a/tests/test_vagrant_test_case.py
+++ b/tests/test_vagrant_test_case.py
@@ -45,7 +45,7 @@ class SingleBoxTests(VagrantTestCase):
 class SpecificMultiBoxTests(VagrantTestCase):
     """Tests for a multiple box setup where only some of the boxes are to be on"""
 
-    vagrant_boxes = [TEST_BOX_NAME.split('/')[1]]
+    vagrant_boxes = [TEST_BOX_NAME.split("/")[1]]
     vagrant_root = MULTI_BOX
 
     def test_all_boxes_up(self):

--- a/tests/test_vagrant_test_case.py
+++ b/tests/test_vagrant_test_case.py
@@ -45,7 +45,7 @@ class SingleBoxTests(VagrantTestCase):
 class SpecificMultiBoxTests(VagrantTestCase):
     """Tests for a multiple box setup where only some of the boxes are to be on"""
 
-    vagrant_boxes = [TEST_BOX_NAME]
+    vagrant_boxes = [TEST_BOX_NAME.split('/')[1]]
     vagrant_root = MULTI_BOX
 
     def test_all_boxes_up(self):


### PR DESCRIPTION
The VM name is now the box name without the generic/ part, so remove
it.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>