### PR TITLE
Fix vagrant output parsing

### DIFF
--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -939,9 +939,7 @@ class Vagrant(object):
         # and will break parsing if included in the status lines.
         # filter them out pending future implementation.
         unneeded_kind = ["metadata", "ui", "action", "Description", "box-info"]
-        parsed_lines = list(
-            filter(lambda x: x[2] not in unneeded_kind, parsed_lines)
-        )
+        parsed_lines = list(filter(lambda x: x[2] not in unneeded_kind, parsed_lines))
         return parsed_lines
 
     def _parse_config(self, ssh_config):

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -938,8 +938,9 @@ class Vagrant(object):
         # vagrant 1.8 adds additional fields that aren't required,
         # and will break parsing if included in the status lines.
         # filter them out pending future implementation.
+        unneeded_kind = ["metadata", "ui", "action", "Description", "box-info"]
         parsed_lines = list(
-            filter(lambda x: x[2] not in ["metadata", "ui", "action"], parsed_lines)
+            filter(lambda x: x[2] not in unneeded_kind, parsed_lines)
         )
         return parsed_lines
 


### PR DESCRIPTION
Vagrant has added some more lines with extra informations
like box-info, Description, so remove them.
This possibly needs to be revisited later to properly deal
with them, for instance, by changing the split() parameter
to 3 and not 4.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>