### PR TITLE
test_boxesvm: Fix dummy box handling

### DIFF
--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -51,6 +51,9 @@ VM_2 = "db"
 TEST_BOX_URL = "generic/alpine315"
 TEST_BOX_NAME = TEST_BOX_URL
 TEST_PROVIDER = "virtualbox"
+TEST_DUMMY_BOX_URL = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "tools", f"dummy-{TEST_PROVIDER}.box"
+)
 # temp dir for testing.
 
 
@@ -455,7 +458,7 @@ def test_boxesvm(test_dir):
         b.name for b in v.box_list()
     ], "There should be no dummy box before it's added."
     # Add a box
-    v.box_add(box_name, TEST_BOX_URL)
+    v.box_add(box_name, TEST_DUMMY_BOX_URL)
 
     # Test that there is a dummy box listed
     box_listing = v.box_list()

--- a/tests/tools/create_dummy_box.sh
+++ b/tests/tools/create_dummy_box.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euxo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if [ $# -ne 1 ]; then
+	echo "Missing provider" >&2
+	exit 1
+fi
+
+if [ -f "$DIR/dummy.box" ]; then
+	echo "Box already created"
+	exit 0
+fi
+
+PROVIDER="$1"
+TMPDIR=`mktemp -d`
+cd "$TMPDIR"
+echo "{ \"provider\": \"$PROVIDER\"}" > metadata.json
+tar czf "$DIR/dummy-$PROVIDER.box" .
+cd "$DIR"
+rm -rf "$TMPDIR"

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,9 @@ minversion = 3.24.5
 [testenv]
 deps =
   .[test]
+commands_pre =
+  {toxinidir}/tests/tools/create_dummy_box.sh virtualbox
+  {toxinidir}/tests/tools/create_dummy_box.sh libvirt
 commands =
   pytest {posargs}
 passenv =


### PR DESCRIPTION
test_boxesvm wants to rename generic/alpine315 but vagrant
doesnt allow it. In order to fix it, create a dummy box and
use it.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>