### PR TITLE
Fix streaming with python3+

### DIFF
--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -596,7 +596,7 @@ def test_streaming_output(vm_dir):
     """
     Test streaming output of up or reload.
     """
-    test_string = "Waiting for machine to boot."
+    test_string = "Machine already provisioned"
     v = vagrant.Vagrant(vm_dir)
 
     with pytest.raises(subprocess.CalledProcessError):

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -1038,7 +1038,7 @@ class Vagrant:
                 cwd=self.root,
                 env=self.env,
                 stdout=subprocess.PIPE,
-                stderr=err_fh
+                stderr=err_fh,
             )
 
             # Iterate over output lines.

--- a/vagrant/__init__.py
+++ b/vagrant/__init__.py
@@ -1038,8 +1038,7 @@ class Vagrant:
                 cwd=self.root,
                 env=self.env,
                 stdout=subprocess.PIPE,
-                stderr=err_fh,
-                bufsize=1,
+                stderr=err_fh
             )
 
             # Iterate over output lines.


### PR DESCRIPTION
    Since python commit for the issue https://bugs.python.org/issue32236,
    python will now raise a ValueError for code like ours, so remove
    bufsize setting to fix it.

    Also fix streaming test test string to be provider agnostic.
    
    Signed-off-by: Arnaud Patard <apatard@hupstream.com>
