### PR TITLE
Fixes non-virtualbox provider

### DIFF
--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -459,7 +459,7 @@ def test_boxesvm(test_dir):
     """
     v = vagrant.Vagrant(test_dir)
     box_name = "python-vagrant-dummy-box"
-    provider = "virtualbox"
+    provider = f"{TEST_PROVIDER}"
 
     # Start fresh with no dummy box
     if box_name in list_box_names():

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -30,6 +30,20 @@ from _pytest.fixtures import FixtureRequest
 import vagrant
 from vagrant import compat
 
+
+# must be defined before TEST_PROVIDER.
+def get_provider() -> str:
+    """
+    Return the provider to use for testing and allow to set it
+    with PYTHON_VAGRANT_TEST_PROVIDER environment variable is set.
+    Defauts to virtualbox
+    """
+    my_prov = "virtualbox"
+    if "PYTHON_VAGRANT_TEST_PROVIDER" in os.environ:
+        my_prov = os.environ["PYTHON_VAGRANT_TEST_PROVIDER"]
+    return my_prov
+
+
 # location of Vagrant executable
 VAGRANT_EXE = vagrant.get_vagrant_executable()
 
@@ -53,7 +67,7 @@ VM_2 = "db"
 # name of the base box used for testing
 TEST_BOX_URL = "generic/alpine315"
 TEST_BOX_NAME = TEST_BOX_URL
-TEST_PROVIDER = "virtualbox"
+TEST_PROVIDER = get_provider()
 TEST_DUMMY_BOX_URL = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "tools", f"dummy-{TEST_PROVIDER}.box"
 )

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ commands =
     --no-cov-on-fail \
   }
 passenv =
+    PYTHON_VAGRANT_TEST_PROVIDER
     # Pass HOME to the test environment as it is required by
     # vagrant. Otherwise error happens due to missing HOME env variable.
     HOME


### PR DESCRIPTION
This PR contains a bunch of fixes to make python-vagrant and its testsuite more provider-agnostic.
The main part is the handling of the state, since vagrant output seems to be dependent of the provider
(for instance "poweroff" versus "shutoff").
