### PR TITLE
 configure vbguest and validate Vagrantfile during lifecycle test

### DIFF
--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -289,7 +289,7 @@ def test_vm_lifecycle(vm_dir):
     if not os.path.isfile(f"{VAGRANT_DIR}/Vagrantfile"):
         with open(f"{VAGRANT_DIR}/Vagrantfile", "w", encoding="UTF-8") as config:
             config.write(
-                'Vagrant.configure("2") do |config|\n  config.vbguest.auto_update = false\nend\n'
+                'Vagrant.configure("2") do |config|\n  config.vbguest.auto_update = false if Vagrant.has_plugin?("vagrant-vbguest")\nend\n'
             )
             VAGRANTFILE_CREATED = True
 

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -271,6 +271,8 @@ def test_vm_status(vm_dir):
 def test_vm_lifecycle(vm_dir):
     """Test methods controlling the VM - init(), up(), suspend(), halt(), destroy()."""
     VAGRANT_DIR = f"{os.environ['HOME']}/.vagrant.d"
+    VAGRANTFILE_CREATED = False
+
     v = vagrant.Vagrant(vm_dir)
 
     # Test init by removing Vagrantfile, since v.init() will create one.
@@ -289,6 +291,7 @@ def test_vm_lifecycle(vm_dir):
             config.write(
                 'Vagrant.configure("2") do |config|\n  config.vbguest.auto_update = false\nend\n'
             )
+            VAGRANTFILE_CREATED = True
 
     v.init(TEST_BOX_NAME)
     assert v.NOT_CREATED == v.status()[0].state
@@ -307,6 +310,9 @@ def test_vm_lifecycle(vm_dir):
 
     v.destroy()
     assert v.NOT_CREATED == v.status()[0].state
+
+    if VAGRANTFILE_CREATED:
+        os.unlink(f"{VAGRANT_DIR}/Vagrantfile")
 
 
 def test_valid_config(vm_dir):


### PR DESCRIPTION
This PR:
- adds a Vagrantfile (if it doesn't exist) to configure `vbguest` in order to pass `init()` and `up()` sequence 
- validates the Vagrantfile after `init()`

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>