### PR TITLE
tox.ini: pass PYTEST_* env variables

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,7 @@ passenv =
     # Pass HOME to the test environment as it is required by
     # vagrant. Otherwise error happens due to missing HOME env variable.
     HOME
+    PYTEST_*
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
 allowlist_externals =


### PR DESCRIPTION
Without this PYTEST_REQPASS would be ignored.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>