### PR TITLE
.github/workflows/tox.yml: add vagrant boxes caching

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -73,6 +73,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Enable vagrant box caching
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.vagrant.d/boxes
+          key: ${{ runner.os }}-${{ matrix.tox_env }}-vagrantbox-${{ hashFiles('tests/tools/create_dummy_box.sh', 'tests/test_vagrant*py', '**/Vagrantfile', 'tests/vagrantfiles/*Vagrantfile') }}
+
       - name: Pip cache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Add caching for the vagrant boxes to avoid errors like:
"An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.
The requested URL returned error: 429"

Fixes: #128
Signed-off-by: Arnaud Patard <apatard@hupstream.com>