### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Switch to using Python 3.8 by default
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: python3 -m pip install --user tox
 
       - name: Check out src from Git
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # needed by setuptools-scm
 

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -69,19 +69,19 @@ jobs:
           fetch-depth: 0 # needed by setuptools-scm
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Enable vagrant box caching
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.vagrant.d/boxes
           key: ${{ runner.os }}-${{ matrix.tox_env }}-vagrantbox-${{ hashFiles('tests/tools/create_dummy_box.sh', 'tests/test_vagrant*py', '**/Vagrantfile', 'tests/vagrantfiles/*Vagrantfile') }}
 
       - name: Pip cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-${{ matrix.tox_env }}-pip-${{ hashFiles('constraints.txt', 'setup.cfg', 'tox.ini', 'pyproject.toml', '.pre-commit-config.yaml', 'pytest.ini') }}
@@ -105,7 +105,7 @@ jobs:
         if: ${{ startsWith(matrix.tox_env, 'py') }}
 
       - name: Archive logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: logs.zip
           path: .tox/**/log/


### PR DESCRIPTION
This PR:
- updates GHA since Node.js 12 actions are deprecated.
- related https://github.com/shyim/junit-report-annotations-action/issues/7