### PR TITLE
Allowlist in glob style

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,8 +35,8 @@ setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
 allowlist_externals =
     sh
-    create_dummy_box.sh
     /home/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh
+    /Users/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh
 
 [testenv:dev]
 commands = {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,7 @@ setenv =
 allowlist_externals =
     sh
     create_dummy_box.sh
+    /home/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh
 
 [testenv:dev]
 commands = {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ passenv =
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
 allowlist_externals =
-    sh
+    *.sh
 
 [testenv:dev]
 commands = {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -35,9 +35,7 @@ setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
 allowlist_externals =
     sh
-    /home/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh
-    /Users/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh
-    create_dummy_box.sh
+    */create_dummy_box.sh
 
 
 [testenv:dev]

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,8 @@ allowlist_externals =
     sh
     /home/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh
     /Users/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh
+    create_dummy_box.sh
+
 
 [testenv:dev]
 commands = {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,8 @@ passenv =
 setenv =
     COVERAGE_FILE = {env:COVERAGE_FILE:{toxworkdir}/.coverage.{envname}}
 allowlist_externals =
-    *.sh
+    sh
+    create_dummy_box.sh
 
 [testenv:dev]
 commands = {posargs}


### PR DESCRIPTION
Set `allowlist_externals` to `sh`, `/home/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh` and `/Users/runner/work/python-vagrant/python-vagrant/tests/tools/create_dummy_box.sh`

See https://github.com/pycontribs/python-vagrant/actions/runs/3622456363/jobs/6107188602#step:10:21 and https://tox.wiki/en/latest/config.html#allowlist_externals

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>