### PR TITLE
Update pyproject and tox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ disable = [
   "invalid-name",
   "missing-function-docstring",
   "no-else-return",
-  "no-self-use",
   "preferred-module",
   "protected-access",
   "too-many-arguments",

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ requires =
 
 [testenv]
 editable = true
-usedevelop = true # needed for coverage
+usedevelop = true
 
 extras =
   test


### PR DESCRIPTION
This PR:
- removes `no-self-use` since it was moved to an optional extension, see https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.
- removes a line comment from tox.ini since it failed with `ConfigError: usedevelop: boolean value 'true # needed for coverage' needs to be 'True' or 'False'`