### PR TITLE
replace macos-10.15 with macos-12

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python-version: ["3.10"]
         os:
-          - macos-10.15
+          - macos-12
         include:
           - tox_env: lint
             os: ubuntu-20.04
@@ -37,13 +37,13 @@ jobs:
             python-version: "3.10"
             skip_vagrant: true
           - tox_env: py39
-            os: macos-10.15
+            os: macos-12
             python-version: "3.9"
           - tox_env: py310
-            os: macos-10.15
+            os: macos-12
             python-version: "3.10"
           - tox_env: py311
-            os: macos-10.15
+            os: macos-12
             python-version: "3.11"
 
     env:


### PR DESCRIPTION
This PR:
- replaces `macos-10.15` with `macos-12` in the GH workflows, due to deprecation. See https://github.com/actions/runner-images/issues/5583

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>