### PR TITLE
Handle failing SSH commands gracefully

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -50,7 +50,7 @@ jobs:
       TOX_PARALLEL_NO_SPINNER: 1
       TOXENV: ${{ matrix.tox_env }}
       FORCE_COLOR: 1
-      PYTEST_REQPASS: 24
+      PYTEST_REQPASS: 25
 
     steps:
       - name: Check vagrant presence

--- a/src/vagrant/__init__.py
+++ b/src/vagrant/__init__.py
@@ -1101,11 +1101,16 @@ class Vagrant:
         # Make subprocess command
         command = self._make_vagrant_command(args)
         with self.err_cm() as err_fh:
-            return compat.decode(
-                subprocess.check_output(
+            try:
+                output = subprocess.check_output(
                     command, cwd=self.root, env=self.env, stderr=err_fh
                 )
-            )
+            except subprocess.CalledProcessError as err:
+                output = err.output
+                log.error(
+                    "Command %s returned with exit code %i", command, err.returncode
+                )
+            return compat.decode(output)
 
     def _stream_vagrant_command(self, args) -> Iterator[str]:
         """

--- a/tests/test_vagrant.py
+++ b/tests/test_vagrant.py
@@ -691,6 +691,18 @@ def test_ssh_command(vm_dir):
     assert output.strip() == "hello"
 
 
+def test_bad_ssh_command(vm_dir, caplog):
+    """
+    Test executing a failing command
+    """
+    v = vagrant.Vagrant(vm_dir, quiet_stderr=False)
+    v.up()
+    v.ssh(command="logger -s oopsie; false")
+    assert "returned with exit code 1" in caplog.text
+    # https://github.com/pytest-dev/pytest/issues/5997
+    # and capsys.readouterr().err == 'vagrant: oopsie'
+
+
 @pytest.mark.parametrize("vm_dir", (MULTIVM_VAGRANTFILE,), indirect=True)
 def test_ssh_command_multivm(vm_dir):
     """


### PR DESCRIPTION
So far, a SSH command returning with a non-zero exit code would cause an exception:

```
Traceback (most recent call last):
  File "/home/georg/Work/git/salt-formulas/../scullery/scullery.py", line 276, in <module>
    main_interactive()
  File "/home/georg/Work/git/salt-formulas/../scullery/scullery.py", line 239, in main_interactive
    runapply(testconf['apply'], target)
  File "/home/georg/Work/git/salt-formulas/../scullery/scullery.py", line 144, in runapply
    sshout = v.ssh(command='sudo {} {}'.format(saltcmd, state))
  File "/usr/lib/python3.10/site-packages/vagrant/__init__.py", line 869, in ssh
    return self._run_vagrant_command(cmd)
  File "/usr/lib/python3.10/site-packages/vagrant/__init__.py", line 1105, in _run_vagrant_command
    subprocess.check_output(
  File "/usr/lib64/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib64/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/usr/bin/vagrant', 'ssh', '--command', 'sudo salt-call --local state.apply foo']' returned non-zero exit status 1.
```

With this patch, such a situation will instead log an error message with the exit code and return the command output regardless:

```
21:27:52 ERROR - _run_vagrant_command: Command ['/usr/bin/vagrant', 'ssh', '--command', 'sudo salt-call --local state.apply foo'] returned with exit code 1
< error output from my salt-call example >
```